### PR TITLE
env-ci-1.l: add virt-external + drop server-3 LACP bundle

### DIFF
--- a/envs/env-ci-1.l/wiring-port-acl.yaml
+++ b/envs/env-ci-1.l/wiring-port-acl.yaml
@@ -1,0 +1,60 @@
+###
+### Port-ACL release test wiring overlay
+###
+### Adds a virtual external (managed Flatcar VM via virt-external) on
+### ds3000-01/E1/2/2 so the inbound-ACL release test in fabricator has
+### a probe source on real Broadcom hardware. The PCI passthrough slot
+### pci@0000:9c:00.1 is already wired (annotation present in the base
+### wiring) and not consumed by any other Connection.
+###
+### When this overlay is loaded, the fabricator vlab-builder creates a
+### virt-external VM with a passthrough NIC at pci@0000:9c:00.1 and the
+### agent provisions ds3000-01/E1/2/2 as an external-attachment ingress,
+### binding the hardcoded inbound ACL there. The release test SSHes to
+### virt-external in this VRF and probes the leaf-side IP.
+###
+### Static (non-proxy) attachment so no BGP session is required from the
+### probe-source VM. The peer is just a Flatcar host with bash; the leaf
+### still applies the same inbound ACL it would for a BGP attachment.
+###
+### static.prefixes is the link subnet only (not 0.0.0.0/0). The release-
+### test helper populateAllExternalVpcPeerings enrolls every non-proxy
+### External into the per-VPC peering matrix; if acl-test advertised
+### 0.0.0.0/0, the locally-attached static route on ds3000-01 would win
+### over the BGP-external route at every other leaf, blackholing default-
+### bound traffic from VPCs anchored on ds3000-01. Restricting to the
+### link subnet keeps the inbound-ACL test functional (the release test
+### probes leaf-myaddr 100.99.100.2 from virt-external 100.99.100.6,
+### both inside this prefix) without polluting general external peering.
+
+apiVersion: vpc.githedgehog.com/v1beta1
+kind: External
+metadata:
+  name: acl-test
+spec:
+  ipv4Namespace: default
+  static:
+    prefixes:
+      - "100.99.100.0/24"
+---
+apiVersion: wiring.githedgehog.com/v1beta1
+kind: Connection
+metadata:
+  name: ds3000-01--external--acl-test
+spec:
+  external:
+    link:
+      switch:
+        port: ds3000-01/E1/2/2
+---
+apiVersion: vpc.githedgehog.com/v1beta1
+kind: ExternalAttachment
+metadata:
+  name: ds3000-01--acl-test
+spec:
+  external: acl-test
+  connection: ds3000-01--external--acl-test
+  static:
+    remoteIP: 100.99.100.6
+    vlan: 100
+    ip: 100.99.100.2/24

--- a/envs/env-ci-1.l/wiring.yaml
+++ b/envs/env-ci-1.l/wiring.yaml
@@ -44,7 +44,7 @@ metadata:
     link.hhfab.githedgehog.com/E1_1_3: pci@0000:4d:00.1
     link.hhfab.githedgehog.com/E1_1_4: pci@0000:4f:00.0
     link.hhfab.githedgehog.com/E1_2_1: pci@0000:9c:00.0
-    link.hhfab.githedgehog.com/E1_2_2: pci@0000:9c:00.1 # not used
+    link.hhfab.githedgehog.com/E1_2_2: pci@0000:9c:00.1 # virt-external (port-acl release test)
   name: ds3000-01
 spec:
   boot:
@@ -685,18 +685,14 @@ metadata:
 apiVersion: wiring.githedgehog.com/v1beta1
 kind: Connection
 metadata:
-  name: server-3--bundled--ds3000-01
+  name: server-3--unbundled--ds3000-01
 spec:
-  bundled:
-    links:
-      - server:
-          port: server-3/enp2s1
-        switch:
-          port: ds3000-01/E1/1/4
-      - server:
-          port: server-3/enp2s2
-        switch:
-          port: ds3000-01/E1/2/2
+  unbundled:
+    link:
+      server:
+        port: server-3/enp2s1
+      switch:
+        port: ds3000-01/E1/1/4
 # ---
 # apiVersion: wiring.githedgehog.com/v1beta1
 # kind: Server


### PR DESCRIPTION
Two commits:

1. `chore(env-ci-1.l): convert server-3 to unbundled` — drops the LACP
   bundle on server-3, leaving a single unbundled link on
   ds3000-01/E1/1/4. Frees the leaf-side port E1/2/2 (PCI passthrough
   slot 9c:00.1) and corrects the stale "# not used" annotation.
   MCLAG-style and LACP-bonded server connections are being
   deprecated; server-3's bundle isn't load-bearing.

2. `env-ci-1.l: add virt-external on ds3000-01/E1/2/2` — adds an
   External + Connection + ExternalAttachment overlay so the
   inbound-ACL release test in fabricator has a managed probe source
   on real Broadcom hardware. The PCI passthrough slot 9c:00.1 maps
   to ds3000-01/E1/2/2 per the (now corrected) base-wiring annotation.

Paired with githedgehog/fabricator#1713.